### PR TITLE
Add complete managedServices to walkthrough template

### DIFF
--- a/walkthroughs/1-template-walkthrough/walkthrough.json
+++ b/walkthroughs/1-template-walkthrough/walkthrough.json
@@ -1,6 +1,14 @@
 {
   "dependencies": {
     "repos": [],
+    "managedServices": [
+      {
+        "name": "amq-online-standard"
+      },
+      {
+        "name": "fuse"
+      }
+    ],
     "serviceInstances": []
   }
 }


### PR DESCRIPTION
Provide an example of the `managedServices` section of `walkthrough.json`